### PR TITLE
fix(core): cross-platform path compatibility

### DIFF
--- a/packages/core/src/executors/update-swagger/executor.spec.ts
+++ b/packages/core/src/executors/update-swagger/executor.spec.ts
@@ -43,10 +43,12 @@ jest.mock('../../generators/utils/get-path-to-startup-assembly', () => ({
     _project: devkit.ProjectConfiguration,
     csProjFilePath: string,
   ) =>
-    join(root, 'dist/apps', projectName, csProjFilePath.replace(
-      'csproj',
-      'dll',
-    )),
+    join(
+      root,
+      'dist/apps',
+      projectName,
+      csProjFilePath.replace('csproj', 'dll'),
+    ),
 }));
 
 describe('Update-Swagger Executor', () => {
@@ -122,62 +124,67 @@ describe('Update-Swagger Executor', () => {
       });
 
     const res = await executor(options, context, dotnetClient);
-    
+
     // First verify that runTool was called
     const runToolMock = (dotnetClient as jest.Mocked<DotNetClient>).runTool;
     expect(runToolMock).toHaveBeenCalled();
-    
+
     // Get the mock calls and verify we have at least one
     const mockCalls = runToolMock.mock.calls;
     expect(mockCalls.length).toBeGreaterThan(0);
-    
+
     // Types safety - add a guard clause to make TypeScript happy
     if (mockCalls.length === 0) {
       throw new Error('runTool was not called');
     }
-    
+
     // Verify the first argument is 'swagger'
     expect(mockCalls[0][0]).toBe('swagger');
-    
+
     // Get the arguments array
     const callArgs = mockCalls[0][1];
-    
+
     // Check if callArgs is defined
     if (!callArgs) {
       throw new Error('Expected callArgs to be defined');
     }
-    
+
     // Now check the arguments array
     expect(Array.isArray(callArgs)).toBe(true);
     expect(callArgs.length).toBeGreaterThanOrEqual(5);
-    
+
     // Verify individual arguments
     expect(callArgs[0]).toBe('tofile');
     expect(callArgs[1]).toBe('--output');
-    
+
     // Create platform-independent path segments for comparison
-    const expectedOutputPath = normalize('libs/generated/my-app-swagger/swagger.json');
+    const expectedOutputPath = normalize(
+      'libs/generated/my-app-swagger/swagger.json',
+    );
     const expectedDllPath = normalize('dist/apps/my-app/1.dll');
-    
+
     // Normalize the paths to handle different path separators
     const normalizedOutputPath = normalize(callArgs[2]);
     const normalizedDllPath = normalize(callArgs[3]);
-    
+
     // Check that paths end with the expected segments
     expect(normalizedOutputPath.includes(expectedOutputPath)).toBeTruthy();
     expect(normalizedDllPath.includes(expectedDllPath)).toBeTruthy();
     expect(callArgs[4]).toBe('v1');
-    
+
     // Compare paths in a platform-independent way
     const expectedCwd = normalize(join(root, 'apps/my-app'));
     if (dotnetClient.cwd) {
       // Extract the path part after the root path
       const actualPath = normalize(dotnetClient.cwd);
-      
+
       // Verify that the path ends with the expected path segment
-      expect(actualPath.endsWith('apps\\my-app') || actualPath.endsWith('apps/my-app')).toBeTruthy();
+      expect(
+        actualPath.endsWith('apps\\my-app') ||
+          actualPath.endsWith('apps/my-app'),
+      ).toBeTruthy();
     }
-    
+
     expect(res.success).toBeTruthy();
   });
 

--- a/packages/core/src/generators/utils/generate-project.spec.ts
+++ b/packages/core/src/generators/utils/generate-project.spec.ts
@@ -170,7 +170,16 @@ describe('nx-dotnet generate-project', () => {
   it('should forward args to dotnet new', async () => {
     options.__unparsed__ = ['--foo', 'bar'];
     options.args = ['--help'];
+    
+    // Create a custom mock for the dotnet client that returns a proper result
     const dotnetClient = new DotNetClient(mockDotnetFactory());
+    
+    // Mock the logAndExecute method to prevent the actual execution
+    // and make it return a successful result instead
+    jest.spyOn(dotnetClient, 'logAndExecute').mockImplementation(() => {
+      return undefined; // Mock successful execution with no return value
+    });
+    
     jest.spyOn(dotnetClient, 'listInstalledTemplates').mockReturnValue([
       {
         shortNames: ['classlib'],
@@ -185,6 +194,7 @@ describe('nx-dotnet generate-project', () => {
         tags: [],
       },
     ]);
+    
     const spy = jest.spyOn(dotnetClient, 'new');
     await GenerateProject(tree, options, dotnetClient, 'library');
     const [, , additionalArguments] = spy.mock.calls[spy.mock.calls.length - 1];

--- a/packages/core/src/generators/utils/generate-project.spec.ts
+++ b/packages/core/src/generators/utils/generate-project.spec.ts
@@ -170,16 +170,16 @@ describe('nx-dotnet generate-project', () => {
   it('should forward args to dotnet new', async () => {
     options.__unparsed__ = ['--foo', 'bar'];
     options.args = ['--help'];
-    
+
     // Create a custom mock for the dotnet client that returns a proper result
     const dotnetClient = new DotNetClient(mockDotnetFactory());
-    
+
     // Mock the logAndExecute method to prevent the actual execution
     // and make it return a successful result instead
     jest.spyOn(dotnetClient, 'logAndExecute').mockImplementation(() => {
       return undefined; // Mock successful execution with no return value
     });
-    
+
     jest.spyOn(dotnetClient, 'listInstalledTemplates').mockReturnValue([
       {
         shortNames: ['classlib'],
@@ -194,7 +194,7 @@ describe('nx-dotnet generate-project', () => {
         tags: [],
       },
     ]);
-    
+
     const spy = jest.spyOn(dotnetClient, 'new');
     await GenerateProject(tree, options, dotnetClient, 'library');
     const [, , additionalArguments] = spy.mock.calls[spy.mock.calls.length - 1];

--- a/packages/core/src/generators/utils/get-path-to-startup-assembly.ts
+++ b/packages/core/src/generators/utils/get-path-to-startup-assembly.ts
@@ -32,9 +32,12 @@ export function buildStartupAssemblyPath(
       .replace('{projectRoot}', project.root),
   );
   if (!existsSync(outputDirectory)) {
-    safeExecSync(`${getPackageManagerCommand().exec} nx ${target} ${projectName}`, {
-      windowsHide: true,
-    });
+    safeExecSync(
+      `${getPackageManagerCommand().exec} nx ${target} ${projectName}`,
+      {
+        windowsHide: true,
+      },
+    );
   }
   const dllName = basename(csProjFilePath).replace(
     /(?:\.csproj|\.vbproj|\.fsproj)$/,

--- a/packages/core/src/generators/utils/get-path-to-startup-assembly.ts
+++ b/packages/core/src/generators/utils/get-path-to-startup-assembly.ts
@@ -10,6 +10,7 @@ import { execSync } from 'child_process';
 import { sync } from 'fast-glob';
 import { existsSync } from 'fs';
 import { basename, relative, resolve } from 'path';
+import { safeExecSync } from '@nx-dotnet/utils';
 
 export function buildStartupAssemblyPath(
   projectName: string,
@@ -31,7 +32,7 @@ export function buildStartupAssemblyPath(
       .replace('{projectRoot}', project.root),
   );
   if (!existsSync(outputDirectory)) {
-    execSync(`${getPackageManagerCommand().exec} nx ${target} ${projectName}`, {
+    safeExecSync(`${getPackageManagerCommand().exec} nx ${target} ${projectName}`, {
       windowsHide: true,
     });
   }

--- a/packages/core/src/tasks/post-install.ts
+++ b/packages/core/src/tasks/post-install.ts
@@ -1,7 +1,8 @@
 import { execSync } from 'child_process';
+import { safeExecSync } from '@nx-dotnet/utils';
 
 try {
-  const version = execSync('dotnet --version', { windowsHide: true })
+  const version = safeExecSync('dotnet --version', { windowsHide: true })
     .toString('utf-8')
     .trim();
   console.info(

--- a/packages/dotnet/src/lib/core/dotnet.factory.ts
+++ b/packages/dotnet/src/lib/core/dotnet.factory.ts
@@ -1,4 +1,5 @@
 import { execSync } from 'child_process';
+import { safeExecSync } from '@nx-dotnet/utils';
 
 /**
  * get CLI command line runner
@@ -16,7 +17,8 @@ export function dotnetFactory(): LoadedCLI {
   // return the command line for local or global dotnet
   // check if dotnet is installed
   try {
-    const version = execSync('dotnet --version', { windowsHide: true })
+    // Use safeExecSync to prevent EBADF errors on Windows when running with NX_ISOLATED_PLUGINS=true
+    const version = safeExecSync('dotnet --version', { windowsHide: true })
       .toString('utf-8')
       .trim();
     return {

--- a/packages/utils/src/lib/utility-functions/childprocess.ts
+++ b/packages/utils/src/lib/utility-functions/childprocess.ts
@@ -1,11 +1,47 @@
 /* eslint-disable @typescript-eslint/no-explicit-any */
 import * as cp from 'child_process';
+import * as os from 'os';
 
 /**
  * TypeScript typings think ChildProcess is an interface, its a class.
  */
 export function isChildProcess(obj: any): obj is cp.ChildProcess {
   return obj instanceof cp.ChildProcess;
+}
+
+/**
+ * Windows-safe implementation of execSync that avoids EBADF errors
+ * when running under Nx with isolated plugins.
+ */
+export function safeExecSync(
+  command: string,
+  options?: cp.ExecSyncOptions,
+): Buffer | string {
+  // Check if we're on Windows and running with isolated plugins
+  const isWindows = os.platform() === 'win32';
+  const isIsolatedPlugins = process.env.NX_ISOLATED_PLUGINS === 'true';
+
+  // Only apply special handling for Windows with isolated plugins
+  if (isWindows && isIsolatedPlugins) {
+    const defaultOptions: cp.ExecSyncOptions = {
+      stdio: 'pipe', // Use 'pipe' instead of 'inherit' to avoid file descriptor issues
+      encoding: undefined, // Use undefined to ensure Buffer return type if not specified by user
+      maxBuffer: 1024 * 1024 * 10, // 10MB buffer
+      windowsHide: true,
+    };
+
+    const mergedOptions = { ...defaultOptions, ...options };
+
+    // Ensure we don't use 'inherit' for stdio on Windows with isolated plugins
+    if (mergedOptions.stdio === 'inherit') {
+      mergedOptions.stdio = 'pipe';
+    }
+
+    return cp.execSync(command, mergedOptions);
+  }
+
+  // Default behavior for non-Windows or when not using isolated plugins
+  return cp.execSync(command, options);
 }
 
 export async function handleChildProcessPassthrough(

--- a/packages/utils/src/lib/utility-functions/dotnet-tools-manifest.spec.ts
+++ b/packages/utils/src/lib/utility-functions/dotnet-tools-manifest.spec.ts
@@ -4,6 +4,7 @@ import {
 } from './dotnet-tools-manifest';
 import * as devkit from '@nx/devkit';
 import * as fs from 'fs';
+import { join } from 'path';
 
 const root = '/virtual';
 jest.mock('@nx/devkit', () => ({
@@ -21,7 +22,9 @@ describe('dotnet tools util functions', () => {
       readJsonFileMock.mockReset();
       existsSyncMock.mockReturnValue(true);
       readJsonFileMock.mockImplementation((p: string): object => {
-        if (p === `${root}/.config/dotnet-tools.json`) {
+        // Use normalized path comparison to handle platform differences
+        const expectedPath = join(root, '.config/dotnet-tools.json');
+        if (p === expectedPath) {
           return {
             version: 1,
             isRoot: true,
@@ -60,7 +63,9 @@ describe('dotnet tools util functions', () => {
 
     it('should return undefined if file wrong version', async () => {
       readJsonFileMock.mockImplementation((p: string): object => {
-        if (p === `${root}/.config/dotnet-tools.json`) {
+        // Use normalized path comparison to handle platform differences
+        const expectedPath = join(root, '.config/dotnet-tools.json');
+        if (p === expectedPath) {
           return {
             version: 99,
             isRoot: true,
@@ -97,7 +102,9 @@ describe('dotnet tools util functions', () => {
     beforeEach(() => {
       existsSyncMock.mockReturnValue(true);
       readJsonFileMock.mockImplementation((p: string): object => {
-        if (p === `${root}/.config/dotnet-tools.json`) {
+        // Use normalized path comparison to handle platform differences
+        const expectedPath = join(root, '.config/dotnet-tools.json');
+        if (p === expectedPath) {
           return {
             version: 1,
             isRoot: true,

--- a/tools/scripts/sandbox.ts
+++ b/tools/scripts/sandbox.ts
@@ -8,7 +8,10 @@ import {
 } from 'fs-extra';
 import { basename, dirname, join, resolve } from 'path';
 import { getWorkspacePackages } from '../utils';
-import { startCleanVerdaccioInstance, killVerdaccioInstance } from './local-registry/setup';
+import {
+  startCleanVerdaccioInstance,
+  killVerdaccioInstance,
+} from './local-registry/setup';
 import { releasePublish, releaseVersion } from 'nx/release';
 import { readFileSync, writeFileSync } from 'fs';
 import { NxJsonConfiguration } from '@nx/devkit';
@@ -18,23 +21,23 @@ const sandboxDirectory = join(__dirname, '../../tmp/sandbox');
 
 export async function setup() {
   copySync('.npmrc.local', '.npmrc');
-  
+
   // Kill any existing Verdaccio instance first
   killVerdaccioInstance();
-  
+
   // Add a small delay before starting a new instance
-  await new Promise(resolve => setTimeout(resolve, 1000));
-  
+  await new Promise((resolve) => setTimeout(resolve, 1000));
+
   try {
     // Try to start Verdaccio with improved error handling
-    console.log("Starting Verdaccio local registry...");
+    console.log('Starting Verdaccio local registry...');
     await startCleanVerdaccioInstance();
-    console.log("Verdaccio started successfully");
+    console.log('Verdaccio started successfully');
   } catch (E) {
-    console.error("Error starting Verdaccio:", E);
-    console.log("Continuing without local registry...");
+    console.error('Error starting Verdaccio:', E);
+    console.log('Continuing without local registry...');
   }
-  
+
   try {
     await releaseVersion({
       specifier: '99.99.99',
@@ -48,8 +51,8 @@ export async function setup() {
     });
     await releasePublish({ registry: 'http://localhost:4872' });
   } catch (error) {
-    console.error("Error during release process:", error);
-    console.log("Continuing with sandbox creation...");
+    console.error('Error during release process:', error);
+    console.log('Continuing with sandbox creation...');
   }
 }
 
@@ -67,7 +70,7 @@ if (require.main === module) {
         )} --preset apps --nxCloud skip --packageManager yarn`,
         {
           cwd: dirname(sandboxDirectory),
-          stdio: 'inherit'
+          stdio: 'inherit',
         },
       );
       copySync('.npmrc.local', join(sandboxDirectory, '.npmrc'));
@@ -75,7 +78,7 @@ if (require.main === module) {
         console.log('Installing workspace packages...');
         safeExecSync(`yarn add --dev ${pkgs.join(' ')}`, {
           cwd: sandboxDirectory,
-          stdio: 'inherit'
+          stdio: 'inherit',
         });
         console.log('Sandbox created at', resolve(sandboxDirectory));
       });


### PR DESCRIPTION
Replace `execSync` with `safeExecSync` for better error handling and cross-platform compatibility. Format code to comply with project style guidelines.

Fixes #924